### PR TITLE
Fix undefined variable in calculation scripts

### DIFF
--- a/Main/Main_app_en/Calcul_tiers_en_bande/script3.js
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/script3.js
@@ -130,14 +130,9 @@ tableContent += headerRow + '</tr>';
 
         newRow += '</tr>';
         table.insertAdjacentHTML('beforeend', newRow);  // Insérez la nouvelle ligne d'abord
-        let newRowElement = table.lastElementChild;  // Accédez à la dernière ligne insérée
-        
-        // Ensuite, définissez la largeur de la première cellule
-        if (firstCellWidth > 0) {
-            newRowElement.firstElementChild.style.width = `${firstCellWidth}px`;
-        } else {
-            newRowElement.firstElementChild.style.width = "valeur_par_défaut"; // Remplacez par la valeur que vous souhaitez
-        }
+
+        // Supprimé: ajustement de la largeur de la première cellule basé sur
+        // une variable inexistante "firstCellWidth" qui provoquait une erreur.
         
         console.log("About to update resultsTable");
 

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/script3.js
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/script3.js
@@ -130,14 +130,9 @@ tableContent += headerRow + '</tr>';
 
         newRow += '</tr>';
         table.insertAdjacentHTML('beforeend', newRow);  // Insérez la nouvelle ligne d'abord
-        let newRowElement = table.lastElementChild;  // Accédez à la dernière ligne insérée
-        
-        // Ensuite, définissez la largeur de la première cellule
-        if (firstCellWidth > 0) {
-            newRowElement.firstElementChild.style.width = `${firstCellWidth}px`;
-        } else {
-            newRowElement.firstElementChild.style.width = "valeur_par_défaut"; // Remplacez par la valeur que vous souhaitez
-        }
+
+        // Supprimé: ajustement de la largeur de la première cellule basé sur
+        // une variable inexistante "firstCellWidth" qui provoquait une erreur.
         
         console.log("About to update resultsTable");
 


### PR DESCRIPTION
## Summary
- remove references to undefined `firstCellWidth` in tier band calculators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68400595b79083258ebadb5e3a6552e4

## Résumé par Sourcery

Supprimer les références à firstCellWidth non défini pour corriger les erreurs dans les scripts de calcul des bandes de niveau

Corrections de bugs :
- Supprimer les références à firstCellWidth non défini dans le script de calcul des bandes de niveau en anglais
- Supprimer les références à firstCellWidth non défini dans le script de calcul des bandes de niveau en français

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove undefined firstCellWidth references to fix errors in tier band calculation scripts

Bug Fixes:
- Remove references to undefined firstCellWidth in English tier band calculator script
- Remove references to undefined firstCellWidth in French tier band calculator script

</details>