### PR TITLE
Fix layout for third octave converter

### DIFF
--- a/Main/Main_app_en/Calcul_tiers_en_bande/styles.css
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/styles.css
@@ -1,7 +1,13 @@
+body {
+    margin: 0;
+    padding: 0;
+}
+
 .container {
-    width: 95%;
-    margin: auto;
-    margin-top: 100px;
+    width: 100%;
+    max-width: 100%;
+    margin: 20px auto;
+    overflow-x: auto;
 }
 
 input {

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/styles.css
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/styles.css
@@ -1,7 +1,13 @@
+body {
+    margin: 0;
+    padding: 0;
+}
+
 .container {
-    width: 95%;
-    margin: auto;
-    margin-top: 100px;
+    width: 100%;
+    max-width: 100%;
+    margin: 20px auto;
+    overflow-x: auto;
 }
 
 input {


### PR DESCRIPTION
## Summary
- tweak CSS for 1/3-octave conversion page
- ensure content fills the screen without large left blank space

## Testing
- `apt-get update`
- `apt-get install -y chromium-browser`
- `apt-get install -y w3m`

------
https://chatgpt.com/codex/tasks/task_e_6840117fa4ec8325bfba7c0ea260b96a