### PR TITLE
Fix layout on octave conversion page

### DIFF
--- a/Main/Main_app_en/Calcul_tiers_en_bande/styles.css
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/styles.css
@@ -13,6 +13,7 @@ body {
     margin: auto;
     margin-top: 100px;
     padding: 20px;
+    overflow-x: auto; /* Prevent large tables from shifting the page */
 }
 
 input {

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/styles.css
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/styles.css
@@ -13,6 +13,7 @@ body {
     margin: auto;
     margin-top: 100px;
     padding: 20px;
+    overflow-x: auto; /* Prevent large tables from shifting the page */
 }
 
 input {


### PR DESCRIPTION
## Summary
- prevent layout shift when the octave conversion tables overflow

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68401372fec48325b73d16c041ae3b0b

## Résumé par Sourcery

Corrections de bugs :
- Activer le défilement horizontal automatique sur les pages de conversion d'octave pour empêcher les grands tableaux de modifier la mise en page.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Enable horizontal overflow auto-scrolling on the octave conversion pages to stop large tables from shifting the layout

</details>