### PR TITLE
Handle locale decimal separators in calculators

### DIFF
--- a/Main/Main_app_en/Calcul_decroissement_distance/script.js
+++ b/Main/Main_app_en/Calcul_decroissement_distance/script.js
@@ -1,3 +1,7 @@
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const initialNoiseLevel = document.getElementById("initialNoiseLevel");
     const initialDistance = document.getElementById("initialDistance");
@@ -8,10 +12,10 @@ document.addEventListener("DOMContentLoaded", function() {
     const historyDiv = document.getElementById("history");
 
     calculateBtn.addEventListener("click", function() {
-        const L1 = parseFloat(initialNoiseLevel.value);
-        const r1 = parseFloat(initialDistance.value);
-        const Q = parseFloat(directivityFactor.value);
-        const r2 = parseFloat(newDistance.value);
+        const L1 = parseLocaleFloat(initialNoiseLevel.value);
+        const r1 = parseLocaleFloat(initialDistance.value);
+        const Q = parseLocaleFloat(directivityFactor.value);
+        const r2 = parseLocaleFloat(newDistance.value);
 
         const L2 = L1 + 10 * Math.log10((4 * Math.PI * Math.pow(r1, 2)) / (Q * 4 * Math.PI * Math.pow(r2, 2)));
         

--- a/Main/Main_app_en/Calcul_tiers_en_bande/script.js
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/script.js
@@ -1,4 +1,9 @@
 console.log("Script loaded");
+
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const table = document.getElementById('conversionTable');
     const resultsTable = document.getElementById('resultsTable');
@@ -109,7 +114,7 @@ document.addEventListener("DOMContentLoaded", function() {
             if (thirds.every(element => element && element.value)) {
                 let sum = 0;
                 thirds.forEach(element => {
-                    sum += Math.pow(10, parseFloat(element.value) / 10);
+                    sum += Math.pow(10, parseLocaleFloat(element.value) / 10);
                 });
                 let octaveLevel = 10 * Math.log10(sum);
                 console.log("Octave Level:", octaveLevel);

--- a/Main/Main_app_en/Calcul_tiers_en_bande/script3.js
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/script3.js
@@ -1,4 +1,9 @@
 console.log("Script loaded");
+
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const table = document.getElementById('conversionTable');
     const resultsTable = document.getElementById('resultsTable');
@@ -105,7 +110,7 @@ tableContent += headerRow + '</tr>';
             if (thirds.every(element => element && element.value)) {
                 let sum = 0;
                 thirds.forEach(element => {
-                    sum += Math.pow(10, parseFloat(element.value) / 10);
+                    sum += Math.pow(10, parseLocaleFloat(element.value) / 10);
                 });
                 let octaveLevel = 10 * Math.log10(sum / 3);
                 console.log("Octave Level:", octaveLevel);

--- a/Main/Main_app_en/Calculs_db_web/script.js
+++ b/Main/Main_app_en/Calculs_db_web/script.js
@@ -1,3 +1,7 @@
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const inputField = document.getElementById("inputField");
     const calculateBtn = document.getElementById("calculateBtn");
@@ -25,10 +29,10 @@ document.addEventListener("DOMContentLoaded", function() {
             let first = true;
             sub_elements.forEach(function(sub_elem) {
                 if (first) {
-                    total_positive += Math.pow(10, parseFloat(sub_elem) / 10);
+                    total_positive += Math.pow(10, parseLocaleFloat(sub_elem) / 10);
                     first = false;
                 } else {
-                    total_negative += Math.pow(10, parseFloat(sub_elem) / 10);
+                    total_negative += Math.pow(10, parseLocaleFloat(sub_elem) / 10);
                 }
             });
         });

--- a/Main/Main_app_en/Calculs_db_web/script.js
+++ b/Main/Main_app_en/Calculs_db_web/script.js
@@ -1,5 +1,32 @@
 function parseLocaleFloat(value) {
-    return parseFloat(String(value).replace(',', '.'));
+    // Convert to string and trim whitespace
+    let str = String(value).trim();
+
+    // Remove non-breaking spaces and normal spaces (common thousands separators)
+    str = str.replace(/\s|\u00A0/g, '');
+
+    // If both ',' and '.' are present, assume the last one is the decimal separator
+    if (str.indexOf(',') > -1 && str.indexOf('.') > -1) {
+        if (str.lastIndexOf(',') > str.lastIndexOf('.')) {
+            // ',' is decimal, '.' is thousands
+            str = str.replace(/\./g, '');
+            str = str.replace(/,/g, '.');
+        } else {
+            // '.' is decimal, ',' is thousands
+            str = str.replace(/,/g, '');
+        }
+    } else if (str.indexOf(',') > -1) {
+        // Only ',' present, assume it's decimal
+        str = str.replace(/,/g, '.');
+    } else {
+        // Only '.' present or neither, assume '.' is decimal
+        // Remove any stray thousands separators (rare, but for safety)
+        str = str.replace(/(?<=\d)\.(?=\d{3}\b)/g, '');
+    }
+
+    // Validate: should be a valid float now
+    const num = parseFloat(str);
+    return isNaN(num) ? NaN : num;
 }
 
 document.addEventListener("DOMContentLoaded", function() {

--- a/Main/Main_app_fr/Calcul_decroissement_distance/script.js
+++ b/Main/Main_app_fr/Calcul_decroissement_distance/script.js
@@ -1,3 +1,7 @@
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const initialNoiseLevel = document.getElementById("initialNoiseLevel");
     const initialDistance = document.getElementById("initialDistance");
@@ -8,10 +12,10 @@ document.addEventListener("DOMContentLoaded", function() {
     const historyDiv = document.getElementById("history");
 
     calculateBtn.addEventListener("click", function() {
-        const L1 = parseFloat(initialNoiseLevel.value);
-        const r1 = parseFloat(initialDistance.value);
-        const Q = parseFloat(directivityFactor.value);
-        const r2 = parseFloat(newDistance.value);
+        const L1 = parseLocaleFloat(initialNoiseLevel.value);
+        const r1 = parseLocaleFloat(initialDistance.value);
+        const Q = parseLocaleFloat(directivityFactor.value);
+        const r2 = parseLocaleFloat(newDistance.value);
 
         const L2 = L1 + 10 * Math.log10((4 * Math.PI * Math.pow(r1, 2)) / (Q * 4 * Math.PI * Math.pow(r2, 2)));
         

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/script.js
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/script.js
@@ -1,4 +1,9 @@
 console.log("Script loaded");
+
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const table = document.getElementById('conversionTable');
     const resultsTable = document.getElementById('resultsTable');
@@ -110,7 +115,7 @@ tableContent += headerRow + '</tr>';
             if (thirds.every(element => element && element.value)) {
                 let sum = 0;
                 thirds.forEach(element => {
-                    sum += Math.pow(10, parseFloat(element.value) / 10);
+                    sum += Math.pow(10, parseLocaleFloat(element.value) / 10);
                 });
                 let octaveLevel = 10 * Math.log10(sum);
                 console.log("Octave Level:", octaveLevel);
@@ -133,4 +138,4 @@ tableContent += headerRow + '</tr>';
     
         resultRow.innerHTML = newCells;  // Mettez à jour la ligne existante
     });
-});    
+});

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/script3.js
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/script3.js
@@ -1,4 +1,9 @@
 console.log("Script loaded");
+
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const table = document.getElementById('conversionTable');
     const resultsTable = document.getElementById('resultsTable');
@@ -105,7 +110,7 @@ tableContent += headerRow + '</tr>';
             if (thirds.every(element => element && element.value)) {
                 let sum = 0;
                 thirds.forEach(element => {
-                    sum += Math.pow(10, parseFloat(element.value) / 10);
+                    sum += Math.pow(10, parseLocaleFloat(element.value) / 10);
                 });
                 let octaveLevel = 10 * Math.log10(sum / 3);
                 console.log("Octave Level:", octaveLevel);

--- a/Main/Main_app_fr/Calculs_db_web/script.js
+++ b/Main/Main_app_fr/Calculs_db_web/script.js
@@ -1,3 +1,7 @@
+function parseLocaleFloat(value) {
+    return parseFloat(String(value).replace(',', '.'));
+}
+
 document.addEventListener("DOMContentLoaded", function() {
     const inputField = document.getElementById("inputField");
     const calculateBtn = document.getElementById("calculateBtn");
@@ -25,10 +29,10 @@ document.addEventListener("DOMContentLoaded", function() {
             let first = true;
             sub_elements.forEach(function(sub_elem) {
                 if (first) {
-                    total_positive += Math.pow(10, parseFloat(sub_elem) / 10);
+                    total_positive += Math.pow(10, parseLocaleFloat(sub_elem) / 10);
                     first = false;
                 } else {
-                    total_negative += Math.pow(10, parseFloat(sub_elem) / 10);
+                    total_negative += Math.pow(10, parseLocaleFloat(sub_elem) / 10);
                 }
             });
         });


### PR DESCRIPTION
## Summary
- Normalize numeric inputs with a new `parseLocaleFloat` helper to handle both comma and dot decimal separators across all calculator scripts.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890d0411f508325b0dcbd73a984eaff

## Résumé par Sourcery

Ajout d'une analyse décimale tenant compte de la locale à tous les scripts de calculatrice pour gérer les séparateurs virgule et point dans les entrées numériques.

Améliorations :
- Introduction d'une fonction d'aide `parseLocaleFloat` qui remplace les virgules par des points avant d'analyser les nombres flottants.
- Remplacement des appels directs à `parseFloat` par `parseLocaleFloat` dans tous les scripts de calculatrice.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add locale-aware decimal parsing to all calculator scripts to handle both comma and dot separators in numeric inputs.

Enhancements:
- Introduce a parseLocaleFloat helper function that replaces commas with dots before parsing floats
- Replace direct parseFloat calls with parseLocaleFloat across all calculator scripts

</details>