### PR TITLE
feat: add theory sections for acoustic calculators

### DIFF
--- a/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
@@ -25,7 +25,6 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
-<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">

--- a/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
@@ -64,6 +64,15 @@
     <div id="result">Result: </div>
     <div id="history">History: <br>--------<br></div>
   </div>
+  <div class="theory-section">
+    <h3>Calculation principle</h3>
+    <p>Sound level decreases with distance because acoustic energy spreads out.</p>
+
+    <p>In free field, the decay law is:</p>
+    <pre>L2 = L1 - 20 × log₁₀(d2 / d1)</pre>
+
+    <p>This law assumes spherical propagation without obstacles or reverberation. In practice, attenuation may be influenced by other factors.</p>
+  </div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
@@ -25,6 +25,7 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
+<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">
@@ -64,15 +65,7 @@
     <div id="result">Result: </div>
     <div id="history">History: <br>--------<br></div>
   </div>
-  <div class="theory-section">
-    <h3>Calculation principle</h3>
-    <p>Sound level decreases with distance because acoustic energy spreads out.</p>
-
-    <p>In free field, the decay law is:</p>
-    <pre>L2 = L1 - 20 × log₁₀(d2 / d1)</pre>
-
-    <p>This law assumes spherical propagation without obstacles or reverberation. In practice, attenuation may be influenced by other factors.</p>
-  </div>
+  <div data-theory="calc-dist-en"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_en/Calcul_decroissement_distance/calc_dist.html
@@ -20,6 +20,7 @@
       { href: '../Calculs_db_web/calc_db.html', label: 'dB Addition' },
       { href: '../Calcul_tiers_en_bande/tiers_en_bande.html', label: 'Third-Octave' }
     ],
+    theory: 'calc-dist-en',
     onMathJaxReady: () => MathJax.typesetPromise()
   };
 </script>
@@ -64,7 +65,6 @@
     <div id="result">Result: </div>
     <div id="history">History: <br>--------<br></div>
   </div>
-  <div data-theory="calc-dist-en"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -25,6 +25,7 @@
     </script>
     <script src="../../header.js" defer></script>
     <script src="script.js" defer></script>
+<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">
@@ -48,15 +49,7 @@
       <table id="resultsTable"></table>
     </div>
   </div>
-  <div class="theory-section">
-    <h3>Calculation principle</h3>
-    <p>The sound spectrum is often analyzed in third-octave bands, standardized according to ISO 266.</p>
-
-    <p>Each band is centered on a frequency (f<sub>c</sub>) and spans:</p>
-    <pre>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</pre>
-
-    <p>This division allows a precise analysis of equipment acoustic behavior according to their frequency response.</p>
-  </div>
+  <div data-theory="calc-tiers-en"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -25,7 +25,6 @@
     </script>
     <script src="../../header.js" defer></script>
     <script src="script.js" defer></script>
-<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">

--- a/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -48,6 +48,15 @@
       <table id="resultsTable"></table>
     </div>
   </div>
+  <div class="theory-section">
+    <h3>Calculation principle</h3>
+    <p>The sound spectrum is often analyzed in third-octave bands, standardized according to ISO 266.</p>
+
+    <p>Each band is centered on a frequency (f<sub>c</sub>) and spans:</p>
+    <pre>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</pre>
+
+    <p>This division allows a precise analysis of equipment acoustic behavior according to their frequency response.</p>
+  </div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_en/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -20,7 +20,8 @@
           { href: '../Calculs_db_web/calc_db.html', label: 'dB Addition' },
           { href: '../Calcul_decroissement_distance/calc_dist.html', label: 'Distance Decay' }
         ],
-        onMathJaxReady: () => MathJax.typesetPromise()
+    theory: 'calc-tiers-en',
+    onMathJaxReady: () => MathJax.typesetPromise()
       };
     </script>
     <script src="../../header.js" defer></script>
@@ -48,7 +49,6 @@
       <table id="resultsTable"></table>
     </div>
   </div>
-  <div data-theory="calc-tiers-en"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_en/Calculs_db_web/calc_db.html
@@ -25,7 +25,6 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
-<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">

--- a/Main/Main_app_en/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_en/Calculs_db_web/calc_db.html
@@ -54,6 +54,15 @@
     <div id="result">Result: </div>
     <div id="history">History: <br>--------<br></div>
   </div>
+  <div class="theory-section">
+    <h3>Calculation principle</h3>
+    <p>Because decibels are a logarithmic scale, levels cannot be added like ordinary numbers.</p>
+
+    <p>Each level is converted to relative power, summed, then converted back to dB:</p>
+    <pre>L_total = 10 × log₁₀(Σ 10^(Li / 10))</pre>
+
+    <p>Note: if a level is much lower than the others, its influence is negligible.</p>
+  </div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_en/Calculs_db_web/calc_db.html
@@ -20,6 +20,7 @@
       { href: '../Calcul_decroissement_distance/calc_dist.html', label: 'Distance Decay' },
       { href: '../Calcul_tiers_en_bande/tiers_en_bande.html', label: 'Third-Octave' }
     ],
+    theory: 'calc-db-en',
     onMathJaxReady: () => MathJax.typesetPromise()
   };
 </script>
@@ -54,7 +55,6 @@
     <div id="result">Result: </div>
     <div id="history">History: <br>--------<br></div>
   </div>
-  <div data-theory="calc-db-en"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_en/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_en/Calculs_db_web/calc_db.html
@@ -25,6 +25,7 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
+<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">
@@ -54,15 +55,7 @@
     <div id="result">Result: </div>
     <div id="history">History: <br>--------<br></div>
   </div>
-  <div class="theory-section">
-    <h3>Calculation principle</h3>
-    <p>Because decibels are a logarithmic scale, levels cannot be added like ordinary numbers.</p>
-
-    <p>Each level is converted to relative power, summed, then converted back to dB:</p>
-    <pre>L_total = 10 × log₁₀(Σ 10^(Li / 10))</pre>
-
-    <p>Note: if a level is much lower than the others, its influence is negligible.</p>
-  </div>
+  <div data-theory="calc-db-en"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
@@ -25,7 +25,6 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
-<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">

--- a/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
@@ -64,6 +64,15 @@
     <div id="result">Résultat : </div>
     <div id="history">Historique : <br>--------<br></div>
   </div>
+  <div class="theory-section">
+    <h3>Principe du calcul</h3>
+    <p>Le niveau sonore diminue avec la distance à cause de la dispersion de l’énergie acoustique.</p>
+
+    <p>Dans un champ libre, la loi de décroissance est :</p>
+    <pre>L2 = L1 - 20 × log₁₀(d2 / d1)</pre>
+
+    <p>Cette loi suppose une propagation sphérique sans obstacle ni réverbération. En pratique, l’atténuation peut être influencée par d’autres facteurs.</p>
+  </div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
@@ -20,6 +20,7 @@
       { href: '../Calculs_db_web/calc_db.html', label: 'Addition dB' },
       { href: '../Calcul_tiers_en_bande/tiers_en_bande.html', label: "Tiers d'octave" }
     ],
+    theory: 'calc-dist-fr',
     onMathJaxReady: () => MathJax.typesetPromise()
   };
 </script>
@@ -64,7 +65,6 @@
     <div id="result">Résultat : </div>
     <div id="history">Historique : <br>--------<br></div>
   </div>
-  <div data-theory="calc-dist-fr"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
+++ b/Main/Main_app_fr/Calcul_decroissement_distance/calc_dist.html
@@ -25,6 +25,7 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
+<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">
@@ -64,15 +65,7 @@
     <div id="result">Résultat : </div>
     <div id="history">Historique : <br>--------<br></div>
   </div>
-  <div class="theory-section">
-    <h3>Principe du calcul</h3>
-    <p>Le niveau sonore diminue avec la distance à cause de la dispersion de l’énergie acoustique.</p>
-
-    <p>Dans un champ libre, la loi de décroissance est :</p>
-    <pre>L2 = L1 - 20 × log₁₀(d2 / d1)</pre>
-
-    <p>Cette loi suppose une propagation sphérique sans obstacle ni réverbération. En pratique, l’atténuation peut être influencée par d’autres facteurs.</p>
-  </div>
+  <div data-theory="calc-dist-fr"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -20,7 +20,8 @@
           { href: '../Calculs_db_web/calc_db.html', label: 'Addition dB' },
           { href: '../Calcul_decroissement_distance/calc_dist.html', label: 'Décroissement' }
         ],
-        onMathJaxReady: () => MathJax.typesetPromise()
+    theory: 'calc-tiers-fr',
+    onMathJaxReady: () => MathJax.typesetPromise()
       };
     </script>
     <script src="../../header.js" defer></script>
@@ -48,7 +49,6 @@
       <table id="resultsTable"></table>
     </div>
   </div>
-  <div data-theory="calc-tiers-fr"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -48,6 +48,15 @@
       <table id="resultsTable"></table>
     </div>
   </div>
+  <div class="theory-section">
+    <h3>Principe du calcul</h3>
+    <p>Le spectre sonore est souvent analysé en bandes de tiers d’octave, normalisées selon la norme ISO 266.</p>
+
+    <p>Chaque bande est centrée sur une fréquence (f<sub>c</sub>) et s’étend de :</p>
+    <pre>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</pre>
+
+    <p>Ce découpage permet d’analyser précisément le comportement acoustique des équipements selon leur réponse en fréquence.</p>
+  </div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -25,7 +25,6 @@
     </script>
     <script src="../../header.js" defer></script>
     <script src="script.js" defer></script>
-<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">

--- a/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
+++ b/Main/Main_app_fr/Calcul_tiers_en_bande/tiers_en_bande.html
@@ -25,6 +25,7 @@
     </script>
     <script src="../../header.js" defer></script>
     <script src="script.js" defer></script>
+<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">
@@ -48,15 +49,7 @@
       <table id="resultsTable"></table>
     </div>
   </div>
-  <div class="theory-section">
-    <h3>Principe du calcul</h3>
-    <p>Le spectre sonore est souvent analysé en bandes de tiers d’octave, normalisées selon la norme ISO 266.</p>
-
-    <p>Chaque bande est centrée sur une fréquence (f<sub>c</sub>) et s’étend de :</p>
-    <pre>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</pre>
-
-    <p>Ce découpage permet d’analyser précisément le comportement acoustique des équipements selon leur réponse en fréquence.</p>
-  </div>
+  <div data-theory="calc-tiers-fr"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_fr/Calculs_db_web/calc_db.html
@@ -25,7 +25,6 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
-<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">

--- a/Main/Main_app_fr/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_fr/Calculs_db_web/calc_db.html
@@ -20,6 +20,7 @@
       { href: '../Calcul_decroissement_distance/calc_dist.html', label: 'Décroissement' },
       { href: '../Calcul_tiers_en_bande/tiers_en_bande.html', label: "Tiers d'octave" }
     ],
+    theory: 'calc-db-fr',
     onMathJaxReady: () => MathJax.typesetPromise()
   };
 </script>
@@ -54,7 +55,6 @@
     <div id="result">Résultat : </div>
     <div id="history">Historique : <br>--------<br></div>
   </div>
-  <div data-theory="calc-db-fr"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_fr/Calculs_db_web/calc_db.html
@@ -25,6 +25,7 @@
 </script>
 <script src="../../header.js" defer></script>
 <script src="script.js" defer></script>
+<script src="../../theory-sections.js" defer></script>
 </head>
 <body>
 <main class="container">
@@ -54,15 +55,7 @@
     <div id="result">Résultat : </div>
     <div id="history">Historique : <br>--------<br></div>
   </div>
-  <div class="theory-section">
-    <h3>Principe du calcul</h3>
-    <p>Les décibels étant une échelle logarithmique, on ne peut pas additionner les niveaux comme des nombres classiques.</p>
-
-    <p>On convertit chaque niveau en puissance relative, on les additionne, puis on reconvertit le total en dB :</p>
-    <pre>L_total = 10 × log₁₀(Σ 10^(Li / 10))</pre>
-
-    <p>Remarque : si un niveau est très inférieur aux autres, son influence est quasi nulle.</p>
-  </div>
+  <div data-theory="calc-db-fr"></div>
 </main>
 </body>
 </html>

--- a/Main/Main_app_fr/Calculs_db_web/calc_db.html
+++ b/Main/Main_app_fr/Calculs_db_web/calc_db.html
@@ -54,6 +54,15 @@
     <div id="result">Résultat : </div>
     <div id="history">Historique : <br>--------<br></div>
   </div>
+  <div class="theory-section">
+    <h3>Principe du calcul</h3>
+    <p>Les décibels étant une échelle logarithmique, on ne peut pas additionner les niveaux comme des nombres classiques.</p>
+
+    <p>On convertit chaque niveau en puissance relative, on les additionne, puis on reconvertit le total en dB :</p>
+    <pre>L_total = 10 × log₁₀(Σ 10^(Li / 10))</pre>
+
+    <p>Remarque : si un niveau est très inférieur aux autres, son influence est quasi nulle.</p>
+  </div>
 </main>
 </body>
 </html>

--- a/Main/calc_styles.css
+++ b/Main/calc_styles.css
@@ -165,3 +165,27 @@ tr.thirds-row td {
 .resultsTable-td {
   border: 2px solid #ccc;
 }
+.theory-section {
+  background-color: #f9f9f9;
+  border-left: 4px solid #4A90E2;
+  padding: 20px;
+  margin-top: 30px;
+  border-radius: 8px;
+  color: #333;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.theory-section h3 {
+  margin-top: 0;
+  font-size: 1.2rem;
+  color: #1A237E;
+}
+
+.theory-section pre {
+  background-color: #eee;
+  padding: 10px;
+  border-radius: 6px;
+  font-family: monospace;
+  overflow-x: auto;
+}

--- a/Main/calc_styles.css
+++ b/Main/calc_styles.css
@@ -165,7 +165,7 @@ tr.thirds-row td {
 .resultsTable-td {
   border: 2px solid #ccc;
 }
-.theory-section {
+.calc-tool__theory {
   background-color: #f9f9f9;
   border-left: 4px solid #4A90E2;
   padding: 20px;
@@ -176,16 +176,20 @@ tr.thirds-row td {
   line-height: 1.6;
 }
 
-.theory-section h3 {
+.calc-tool__theory h2 {
   margin-top: 0;
   font-size: 1.2rem;
   color: #1A237E;
 }
 
-.theory-section pre {
+.calc-tool__theory pre {
   background-color: #eee;
   padding: 10px;
   border-radius: 6px;
   font-family: monospace;
   overflow-x: auto;
+}
+
+.calc-tool__theory code {
+  font-family: inherit;
 }

--- a/Main/header.js
+++ b/Main/header.js
@@ -1,14 +1,11 @@
 (function(){
-  const currentScript = document.currentScript;
-  const basePath = currentScript ? currentScript.src.replace(/[^/]+$/, '') : '';
-  if (basePath) {
-    const theorySrc = `${basePath}theory-sections.js`;
-    if (!document.querySelector(`script[src="${theorySrc}"]`)) {
-      document.head.appendChild(Object.assign(
-        document.createElement('script'),
-        { src: theorySrc, defer: true }
-      ));
-    }
+  const scriptEl = document.currentScript || document.querySelector('script[src*="header.js"]');
+  const theorySrc = scriptEl ? new URL('theory-sections.js', scriptEl.src).href : null;
+  if (theorySrc && !document.querySelector(`script[src="${theorySrc}"]`)) {
+    const s = document.createElement('script');
+    s.src = theorySrc;
+    s.defer = true;
+    document.head.appendChild(s);
   }
   const cfg = window.headerConfig || {};
   document.addEventListener('DOMContentLoaded', () => {

--- a/Main/header.js
+++ b/Main/header.js
@@ -1,4 +1,15 @@
 (function(){
+  const currentScript = document.currentScript;
+  const basePath = currentScript ? currentScript.src.replace(/[^/]+$/, '') : '';
+  if (basePath) {
+    const theorySrc = `${basePath}theory-sections.js`;
+    if (!document.querySelector(`script[src="${theorySrc}"]`)) {
+      document.head.appendChild(Object.assign(
+        document.createElement('script'),
+        { src: theorySrc, defer: true }
+      ));
+    }
+  }
   const cfg = window.headerConfig || {};
   document.addEventListener('DOMContentLoaded', () => {
     const gtagUrl = 'https://www.googletagmanager.com/gtag/js?id=G-YET08GB3VB';

--- a/Main/theory-sections.js
+++ b/Main/theory-sections.js
@@ -1,0 +1,67 @@
+(function(){
+  const sections = {
+    'calc-db-fr': `
+<section class="calc-tool__theory" aria-labelledby="theory-db-fr">
+  <h2 id="theory-db-fr">Principe du calcul</h2>
+  <p>Les décibels étant une échelle logarithmique, on ne peut pas additionner les niveaux comme des nombres classiques.</p>
+  <p>On convertit chaque niveau en puissance relative, on les additionne, puis on reconvertit le total en dB :</p>
+  <pre><code>L_total = 10 × log₁₀(Σ 10^(Li / 10))</code></pre>
+  <p>Remarque : si un niveau est très inférieur aux autres, son influence est quasi nulle.</p>
+</section>
+`,
+    'calc-db-en': `
+<section class="calc-tool__theory" aria-labelledby="theory-db-en">
+  <h2 id="theory-db-en">Calculation principle</h2>
+  <p>Because decibels are a logarithmic scale, levels cannot be added like ordinary numbers.</p>
+  <p>Each level is converted to relative power, summed, then converted back to dB:</p>
+  <pre><code>L_total = 10 × log₁₀(Σ 10^(Li / 10))</code></pre>
+  <p>Note: if a level is much lower than the others, its influence is negligible.</p>
+</section>
+`,
+    'calc-dist-fr': `
+<section class="calc-tool__theory" aria-labelledby="theory-dist-fr">
+  <h2 id="theory-dist-fr">Principe du calcul</h2>
+  <p>Le niveau sonore diminue avec la distance à cause de la dispersion de l’énergie acoustique.</p>
+  <p>Dans un champ libre, la loi de décroissance est :</p>
+  <pre><code>L2 = L1 - 20 × log₁₀(d2 / d1)</code></pre>
+  <p>Cette loi suppose une propagation sphérique sans obstacle ni réverbération. En pratique, l’atténuation peut être influencée par d’autres facteurs.</p>
+</section>
+`,
+    'calc-dist-en': `
+<section class="calc-tool__theory" aria-labelledby="theory-dist-en">
+  <h2 id="theory-dist-en">Calculation principle</h2>
+  <p>Sound level decreases with distance due to the dispersion of acoustic energy.</p>
+  <p>In free field, the decay law is:</p>
+  <pre><code>L2 = L1 - 20 × log₁₀(d2 / d1)</code></pre>
+  <p>This law assumes spherical propagation without obstacles or reverberation. In practice, attenuation can be influenced by other factors.</p>
+</section>
+`,
+    'calc-tiers-fr': `
+<section class="calc-tool__theory" aria-labelledby="theory-tiers-fr">
+  <h2 id="theory-tiers-fr">Principe du calcul</h2>
+  <p>Le spectre sonore est souvent analysé en bandes de tiers d’octave, normalisées selon la norme ISO 266.</p>
+  <p>Chaque bande est centrée sur une fréquence (f<sub>c</sub>) et s’étend de :</p>
+  <pre><code>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</code></pre>
+  <p>Ce découpage permet d’analyser précisément le comportement acoustique des équipements selon leur réponse en fréquence.</p>
+</section>
+`,
+    'calc-tiers-en': `
+<section class="calc-tool__theory" aria-labelledby="theory-tiers-en">
+  <h2 id="theory-tiers-en">Calculation principle</h2>
+  <p>The sound spectrum is often analyzed in third-octave bands, standardized by ISO 266.</p>
+  <p>Each band is centered on a frequency (f<sub>c</sub>) and spans:</p>
+  <pre><code>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</code></pre>
+  <p>This segmentation allows precise analysis of equipment acoustic behavior according to their frequency response.</p>
+</section>
+`
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-theory]').forEach(el => {
+      const key = el.getAttribute('data-theory');
+      if (sections[key]) {
+        el.outerHTML = sections[key];
+      }
+    });
+  });
+})();

--- a/Main/theory-sections.js
+++ b/Main/theory-sections.js
@@ -1,67 +1,137 @@
 (function(){
-  const sections = {
-    'calc-db-fr': `
-<section class="calc-tool__theory" aria-labelledby="theory-db-fr">
-  <h2 id="theory-db-fr">Principe du calcul</h2>
-  <p>Les décibels étant une échelle logarithmique, on ne peut pas additionner les niveaux comme des nombres classiques.</p>
-  <p>On convertit chaque niveau en puissance relative, on les additionne, puis on reconvertit le total en dB :</p>
-  <pre><code>L_total = 10 × log₁₀(Σ 10^(Li / 10))</code></pre>
-  <p>Remarque : si un niveau est très inférieur aux autres, son influence est quasi nulle.</p>
-</section>
-`,
-    'calc-db-en': `
-<section class="calc-tool__theory" aria-labelledby="theory-db-en">
-  <h2 id="theory-db-en">Calculation principle</h2>
-  <p>Because decibels are a logarithmic scale, levels cannot be added like ordinary numbers.</p>
-  <p>Each level is converted to relative power, summed, then converted back to dB:</p>
-  <pre><code>L_total = 10 × log₁₀(Σ 10^(Li / 10))</code></pre>
-  <p>Note: if a level is much lower than the others, its influence is negligible.</p>
-</section>
-`,
-    'calc-dist-fr': `
-<section class="calc-tool__theory" aria-labelledby="theory-dist-fr">
-  <h2 id="theory-dist-fr">Principe du calcul</h2>
-  <p>Le niveau sonore diminue avec la distance à cause de la dispersion de l’énergie acoustique.</p>
-  <p>Dans un champ libre, la loi de décroissance est :</p>
-  <pre><code>L2 = L1 - 20 × log₁₀(d2 / d1)</code></pre>
-  <p>Cette loi suppose une propagation sphérique sans obstacle ni réverbération. En pratique, l’atténuation peut être influencée par d’autres facteurs.</p>
-</section>
-`,
-    'calc-dist-en': `
-<section class="calc-tool__theory" aria-labelledby="theory-dist-en">
-  <h2 id="theory-dist-en">Calculation principle</h2>
-  <p>Sound level decreases with distance due to the dispersion of acoustic energy.</p>
-  <p>In free field, the decay law is:</p>
-  <pre><code>L2 = L1 - 20 × log₁₀(d2 / d1)</code></pre>
-  <p>This law assumes spherical propagation without obstacles or reverberation. In practice, attenuation can be influenced by other factors.</p>
-</section>
-`,
-    'calc-tiers-fr': `
-<section class="calc-tool__theory" aria-labelledby="theory-tiers-fr">
-  <h2 id="theory-tiers-fr">Principe du calcul</h2>
-  <p>Le spectre sonore est souvent analysé en bandes de tiers d’octave, normalisées selon la norme ISO 266.</p>
-  <p>Chaque bande est centrée sur une fréquence (f<sub>c</sub>) et s’étend de :</p>
-  <pre><code>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</code></pre>
-  <p>Ce découpage permet d’analyser précisément le comportement acoustique des équipements selon leur réponse en fréquence.</p>
-</section>
-`,
-    'calc-tiers-en': `
-<section class="calc-tool__theory" aria-labelledby="theory-tiers-en">
-  <h2 id="theory-tiers-en">Calculation principle</h2>
-  <p>The sound spectrum is often analyzed in third-octave bands, standardized by ISO 266.</p>
-  <p>Each band is centered on a frequency (f<sub>c</sub>) and spans:</p>
-  <pre><code>[f<sub>c</sub> / √2 ; f<sub>c</sub> × √2]</code></pre>
-  <p>This segmentation allows precise analysis of equipment acoustic behavior according to their frequency response.</p>
-</section>
-`
-  };
-
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('[data-theory]').forEach(el => {
-      const key = el.getAttribute('data-theory');
-      if (sections[key]) {
-        el.outerHTML = sections[key];
+  const buildFragment = (parts) => {
+    const frag = document.createDocumentFragment();
+    parts.forEach(part => {
+      if (typeof part === 'string') {
+        frag.append(part);
+      } else if (part.type === 'sub') {
+        const el = document.createElement('sub');
+        el.textContent = part.text;
+        frag.appendChild(el);
       }
     });
-  });
+    return frag;
+  };
+
+  const buildSection = ({ id, title, paras, code }) => {
+    const section = document.createElement('section');
+    section.className = 'calc-tool__theory';
+    section.setAttribute('aria-labelledby', `theory-${id}`);
+
+    const h2 = document.createElement('h2');
+    h2.id = `theory-${id}`;
+    h2.textContent = title;
+    section.appendChild(h2);
+
+    paras.forEach(p => {
+      const pEl = document.createElement('p');
+      if (Array.isArray(p)) {
+        pEl.append(buildFragment(p));
+      } else {
+        pEl.textContent = p;
+      }
+      section.appendChild(pEl);
+    });
+
+    if (code) {
+      const pre = document.createElement('pre');
+      const codeEl = document.createElement('code');
+      if (Array.isArray(code)) {
+        codeEl.append(buildFragment(code));
+      } else {
+        codeEl.textContent = code;
+      }
+      pre.appendChild(codeEl);
+      section.appendChild(pre);
+    }
+
+    return section;
+  };
+
+  const sectionsConfig = [
+    {
+      key: 'calc-db-fr',
+      id: 'db-fr',
+      title: 'Principe du calcul',
+      paras: [
+        'Les décibels étant une échelle logarithmique, on ne peut pas additionner les niveaux comme des nombres classiques.',
+        'On convertit chaque niveau en puissance relative, on les additionne, puis on reconvertit le total en dB :',
+        'Remarque : si un niveau est très inférieur aux autres, son influence est quasi nulle.'
+      ],
+      code: 'L_total = 10 × log₁₀(Σ 10^(Li / 10))'
+    },
+    {
+      key: 'calc-db-en',
+      id: 'db-en',
+      title: 'Calculation principle',
+      paras: [
+        'Because decibels are a logarithmic scale, levels cannot be added like ordinary numbers.',
+        'Each level is converted to relative power, summed, then converted back to dB:',
+        'Note: if a level is much lower than the others, its influence is negligible.'
+      ],
+      code: 'L_total = 10 × log₁₀(Σ 10^(Li / 10))'
+    },
+    {
+      key: 'calc-dist-fr',
+      id: 'dist-fr',
+      title: 'Principe du calcul',
+      paras: [
+        'Le niveau sonore diminue avec la distance à cause de la dispersion de l’énergie acoustique.',
+        'Dans un champ libre, la loi de décroissance est :',
+        'Cette loi suppose une propagation sphérique sans obstacle ni réverbération. En pratique, l’atténuation peut être influencée par d’autres facteurs.'
+      ],
+      code: 'L2 = L1 - 20 × log₁₀(d2 / d1)'
+    },
+    {
+      key: 'calc-dist-en',
+      id: 'dist-en',
+      title: 'Calculation principle',
+      paras: [
+        'Sound level decreases with distance due to the dispersion of acoustic energy.',
+        'In free field, the decay law is:',
+        'This law assumes spherical propagation without obstacles or reverberation. In practice, attenuation can be influenced by other factors.'
+      ],
+      code: 'L2 = L1 - 20 × log₁₀(d2 / d1)'
+    },
+    {
+      key: 'calc-tiers-fr',
+      id: 'tiers-fr',
+      title: 'Principe du calcul',
+      paras: [
+        'Le spectre sonore est souvent analysé en bandes de tiers d’octave, normalisées selon la norme ISO 266.',
+        ['Chaque bande est centrée sur une fréquence (f', { type: 'sub', text: 'c' }, ') et s’étend de :'],
+        'Ce découpage permet d’analyser précisément le comportement acoustique des équipements selon leur réponse en fréquence.'
+      ],
+      code: ['[f', { type: 'sub', text: 'c' }, ' / √2 ; f', { type: 'sub', text: 'c' }, ' × √2]']
+    },
+    {
+      key: 'calc-tiers-en',
+      id: 'tiers-en',
+      title: 'Calculation principle',
+      paras: [
+        'The sound spectrum is often analyzed in third-octave bands, standardized by ISO 266.',
+        ['Each band is centered on a frequency (f', { type: 'sub', text: 'c' }, ') and spans:'],
+        'This segmentation allows precise analysis of equipment acoustic behavior according to their frequency response.'
+      ],
+      code: ['[f', { type: 'sub', text: 'c' }, ' / √2 ; f', { type: 'sub', text: 'c' }, ' × √2]']
+    }
+  ];
+
+  const sections = Object.fromEntries(sectionsConfig.map(cfg => [cfg.key, buildSection(cfg)]));
+
+  const inject = () => {
+    document.querySelectorAll('[data-theory]').forEach(el => {
+      const key = el.getAttribute('data-theory');
+      const section = sections[key];
+      if (section) {
+        el.replaceWith(section.cloneNode(true));
+      }
+    });
+  };
+
+  if (document.readyState !== 'loading') {
+    inject();
+  } else {
+    document.addEventListener('DOMContentLoaded', inject);
+  }
 })();


### PR DESCRIPTION
## Summary
- add explanatory theory sections to dB addition, distance decay, and third-octave tools in French and English
- style theory sections with a shared CSS block for consistent appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936c431ec88325b91879575f4354ee

## Résumé par Sourcery

Introduire des sections théoriques explicatives aux outils de calcul acoustique et appliquer un style cohérent via une classe CSS partagée.

Nouvelles fonctionnalités :
- Ajouter des sections théoriques explicatives aux calculateurs d'addition de dB, de décroissance de distance et de bandes de tiers d'octave en anglais et en français

Améliorations :
- Définir un bloc CSS unifié `.theory-section` pour un style cohérent du contenu explicatif

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Ajoute des sections théoriques explicatives multilingues aux calculateurs acoustiques et applique un style cohérent via un CSS partagé et un script d'injection dynamique

Nouvelles Fonctionnalités :
- Ajoute des sections théoriques expliquant l'addition de dB, la décroissance avec la distance et les calculs de bandes d'un tiers d'octave en anglais et en français
- Injecte dynamiquement le contenu théorique dans les pages des calculateurs en utilisant theory-sections.js

Améliorations :
- Introduit un bloc CSS partagé .calc-tool__theory pour un style cohérent des sections théoriques

<details>
<summary>Original summary in English</summary>

## Résumé par Sourcery

Ajout de sections théoriques multilingues aux calculateurs acoustiques avec un style cohérent et une injection dynamique

Nouvelles Fonctionnalités :
- Introduction de contenu théorique explicatif en anglais et en français pour les calculateurs d'addition de dB, d'atténuation avec la distance et de bandes du tiers d'octave
- Injection dynamique des sections théoriques dans les pages des calculateurs via un nouveau script theory-sections.js et une logique d'en-tête mise à jour

Améliorations :
- Ajout d'une classe CSS partagée .calc-tool__theory et de styles associés pour une apparence cohérente des sections théoriques

<details>
<summary>Original summary in English</summary>

Voici la traduction du résumé de la pull request :

## Résumé par Sourcery

Introduit des sections théoriques explicatives pour les calculateurs acoustiques, stylisées de manière cohérente et injectées dynamiquement via un nouveau script.

Nouvelles fonctionnalités :
- Ajout de contenu théorique multilingue pour les calculateurs d'addition de dB, d'atténuation avec la distance et de tiers d'octave

Améliorations :
- Définition d'une classe CSS partagée pour un style cohérent des sections théoriques
- Mise à jour de la logique d'en-tête pour charger et différer le script theory-sections.js et injecter le contenu théorique dynamiquement

Tâches :
- Configuration de la clé de théorie dans le HTML de chaque calculateur pour permettre l'injection de section

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce explanatory theory sections for the acoustic calculators, styled consistently and injected dynamically via a new script.

New Features:
- Add multilingual theory content for dB addition, distance decay, and third-octave calculators

Enhancements:
- Define a shared CSS class for consistent styling of theory sections
- Update header logic to load and defer the theory-sections.js script and inject theory content dynamically

Chores:
- Configure the theory key in each calculator’s HTML to enable section injection

</details>

</details>

</details>

</details>